### PR TITLE
Rider cancel

### DIFF
--- a/nodeAppPostPg/stage.sql
+++ b/nodeAppPostPg/stage.sql
@@ -1,0 +1,92 @@
+CREATE FUNCTION stage.cancel_ride("rider_UUID" character varying(50)) 
+  RETURNS integer AS $$
+DECLARE
+    retVal integer := -1;
+BEGIN
+    RAISE NOTICE 'tstamp here is %', tstamp; 
+
+    -- get timestamp of unprocessed riders 
+    IF EXISTS (
+      SELECT stage.websubmission_rider."UUID" 
+      FROM stage.status_rider  
+        INNER JOIN 
+          stage.websubmission_rider 
+        ON 
+          (stage.websubmission_rider."CreatedTimeStamp" = stage.status_rider."CreatedTimeStamp") 
+         
+      WHERE 
+        stage.websubmission_rider."UUID" = "rider_UUID"
+    )
+    THEN
+      -- select MAX("CreatedTimeStamp") into tstamp from stage.status_rider;
+      retVal := 1;      
+    ELSE 
+      RETURN retVal;
+      -- tstamp := '2010-01-01';
+    END IF;
+
+    -- create intermediate table of timestamps, processed flag and riderId
+    -- INSERT INTO 
+    --   stage.status_rider ("CreatedTimeStamp")     
+    -- SELECT 
+    --   "CreatedTimeStamp" FROM stage.websubmission_rider 
+    -- WHERE 
+    --   "CreatedTimeStamp" > tstamp;
+
+    -- create riders in nov2016 db
+    -- only insert riders in intermediate tables, and with status == 1
+    -- ?? timestamp to be creation of nov2016 row, or original submission ??
+    -- INSERT INTO 
+    --   nov2016.rider 
+    --     (
+    --     "RiderID", "Name", "Phone", "Email", "EmailValidated",
+    --     "State", "City", "Notes", "DataEntryPoint", "VulnerablePopulation",
+    --     "NeedsWheelChair", "Active"
+    --     )     
+    -- SELECT
+    --   stage.status_rider."RiderID",
+    --   concat_ws(' ', 
+    --             stage.websubmission_rider."RiderFirstName"::text, 
+    --             stage.websubmission_rider."RiderLastName"::text) 
+    --   ,
+    --   stage.websubmission_rider."RiderPhone",
+    --   stage.websubmission_rider."RiderEmail",
+    --   stage.websubmission_rider."RiderEmailValidated"::int::bit,
+
+    --   stage.websubmission_rider."RiderVotingState",
+    --   'city?',
+    --   'notes?',
+    --   'entry?',
+    --   stage.websubmission_rider."RiderIsVulnerable"::int::bit,
+
+    --   stage.websubmission_rider."NeedWheelchair"::int::bit,
+    --   true::int::bit
+    -- FROM 
+    --   stage.websubmission_rider
+    -- INNER JOIN 
+    --   stage.status_rider 
+    -- ON 
+    --   (stage.websubmission_rider."CreatedTimeStamp" = stage.status_rider."CreatedTimeStamp") 
+    -- WHERE 
+    --       stage.websubmission_rider."CreatedTimeStamp" > tstamp 
+    --   AND stage.status_rider.status = 1;
+    
+    -- UPDATE 
+    --   stage.status_rider
+    -- SET
+    --   status = 100
+    -- WHERE
+    --       stage.status_rider."CreatedTimeStamp" > tstamp 
+    --   AND stage.status_rider.status = 1;
+
+    -- RAISE EXCEPTION 'Nonexistent ID --> %', user_id
+    --   USING HINT = 'Please check your user ID';
+
+    RETURN retVal;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT ALL ON FUNCTION stage.cancel_ride("rider_UUID" character varying(50)) TO carpool_admins;
+GRANT EXECUTE ON FUNCTION stage.cancel_ride("rider_UUID" character varying(50)) TO carpool_web_role;
+GRANT EXECUTE ON FUNCTION stage.cancel_ride("rider_UUID" character varying(50)) TO carpool_role;
+

--- a/nodeAppPostPg/stage.sql
+++ b/nodeAppPostPg/stage.sql
@@ -1,3 +1,10 @@
+GRANT SELECT ON TABLE stage.status_rider TO carpool_web_role;
+GRANT SELECT ON TABLE stage.websubmission_rider TO carpool_web_role;
+
+GRANT USAGE ON SCHEMA nov2016 TO carpool_web_role;
+GRANT EXECUTE ON FUNCTION nov2016.cancel_ride_by_rider("RiderID" integer, "RequestedRideID" integer) TO carpool_web_role;
+GRANT ALL ON TABLE nov2016.requested_ride TO carpool_web_role;
+
     -- // get uuid and last Name
     -- // from uuid, get timestamp then riderId from statusRider
     -- // execute nov2016 cancel_ride_by_rider 
@@ -33,14 +40,14 @@ BEGIN
         ON 
           (stage.websubmission_rider."CreatedTimeStamp" = stage.status_rider."CreatedTimeStamp") 
       WHERE 
-        stage.websubmission_rider."UUID" = "rider_UUID";
+        stage.websubmission_rider."UUID" = $1;
 
       retVal := 2;      
     ELSE 
-      RETURN retVal;
+      -- RETURN retVal;
+      RAISE EXCEPTION 'UUID not found %', $1; 
     END IF;
 
-    -- RAISE NOTICE 'riderID here is %', riderID; 
 
     SELECT nov2016.cancel_ride_by_rider(riderID) INTO retVal;
     


### PR DESCRIPTION
prototype of node app DELETE route (for cancelling a ride by uuid)

Stage.sql needs to be run before testing. This is mentioned in the Readme

The node app is perfectly able to be extended for new routes as we need them. However, it's pushing the boundaries of the db permissions granted to the carpool_web_role that it is using currently. Several items in Stage.sql are extra permissions for this role. Perhaps this can be refactored after the demo
