### PR TITLE
Node app routes for Matches info

### DIFF
--- a/nodeAppPostPg/ReadMe.md
+++ b/nodeAppPostPg/ReadMe.md
@@ -19,7 +19,7 @@ STEPS TO INSTALL ON LINUX
 #########################  
 
 DATABASE 
-Run stage.sql
+Run matches.sql
 
 
 ENV VARS REQUIRED 

--- a/nodeAppPostPg/matches.sql
+++ b/nodeAppPostPg/matches.sql
@@ -1,0 +1,4 @@
+GRANT USAGE ON SCHEMA nov2016 TO carpool_web_role;
+
+GRANT SELECT ON TABLE stage.websubmission_rider TO carpool_web_role;
+GRANT SELECT ON TABLE stage.websubmission_driver TO carpool_web_role;


### PR DESCRIPTION
This PR enables the node app to provide info on matches for the demo. It has been tested with the matching engine running on my local isolated system.

Run the matches.sql script on the relevant db. It adds necessary permissions to the relevant db role. The script is also mentioned in the readme, and visible in the PR.

Info on matches and their uuids may be found by this route:
https://server.../matches

The UUIDs can be used like this:
https://server.../match-rider/uuid number
https://server.../match-driver/uuid number