### PR TITLE
Patch redirect

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,3 +4,34 @@
 
 ## Ideally, these would be revised to have no manual steps and be part of a docker compose setup.
 
+# 1) pg-auto
+# cd .../voteUSbackend/docker/pg-auto
+## check .sh files for LF
+
+## Use docker build step with REPO & BRANCH_NAME as relevant
+## docker build -t pgres-cp --build-arg CACHEBUST=$(date +%s) --build-arg REPO=https://github.com/jkbits1/backend --build-arg BRANCH_NAME=master .
+
+# cd .../voteUSbackend
+# execute run command, with volumes if required
+
+
+# 2) nodeApp
+## cd .../voteUSbackend/docker/nodeApp
+## check .sh files for LF
+
+## Use docker build step with REPO & BRANCH_NAME as relevant
+## docker build -t pgres-cp --build-arg CACHEBUST=$(date +%s) --build-arg REPO=https://github.com/jkbits1/backend --build-arg BRANCH_NAME=master .
+
+# cd .../voteUSbackend
+# execute relevant run command, with volumes if required
+
+
+# 3) jekyll
+# cd .../voteUSbackend/docker/jekyll
+
+## Use docker build step with REPO & BRANCH_NAME as relevant
+## docker build -t gc-jekyll --build-arg CACHEBUST=$(date +%s) --build-arg REPO=https://github.com/jkbits1/voteamerica.github.io --build-arg BRANCH_NAME=master .
+
+# IMPORTANT to be careful, jekyll can WIPE folders !!!! 
+# cd .../voteUSfrontend/
+# execute relevant run command, with volumes if required

--- a/docker/jekyll/README.md
+++ b/docker/jekyll/README.md
@@ -2,6 +2,9 @@
 # create docker machine for jekyll
 #
 
+## FOLDER 
+# cd VM_share/Jon/Documents/GitHub/voteUSbackend/docker/jekyll
+
 ## docker build -t gc-jekyll --build-arg CACHEBUST=$(date +%s) --build-arg REPO=https://github.com/voteamerica/voteamerica.github.io --build-arg BRANCH_NAME=master .
 
 ## FOLDER

--- a/nodeAppPostPg/postgresQueries.js
+++ b/nodeAppPostPg/postgresQueries.js
@@ -134,6 +134,64 @@ var PostgresQueries = (function () {
         });
     };
 	
+	PostgresQueries.prototype.dbExecuteCarpoolAPIFunction_Insert = function (payload, pool, fnExecuteFunctionString, fnPayloadArray, req, reply, results) {
+        var queryString = fnExecuteFunctionString();
+        console.log("executeFunctionString Insert: " + queryString);
+        pool.query(queryString, fnPayloadArray(req, payload))
+            .then(function (result) {
+            var firstRow = "";
+
+            var displayResult = result || '';
+            var uuid = "";
+            var code = "";
+            var info = "";
+            try {
+                displayResult = JSON.stringify(result);
+                uuid = result.rows[0].out_uuid;
+                code = result.rows[0].out_error_code;
+                info = result.rows[0].out_error_text;
+                console.error('row: ' + JSON.stringify(result.rows[0]));
+            }
+            catch (err) {
+                console.error('no uuid returned');
+            }
+
+            if (result !== undefined && result.rows !== undefined) {
+                // result.rows.forEach( val => console.log(val));
+                result.rows.forEach(function (val) {
+                    return console.log("exec fn: " + val);
+                });
+                firstRow = result.rows[0];
+            }
+            console.error("executed fn: " + firstRow);
+            
+            if (payload._redirect && uuid) {
+                var reply_url = payload._redirect + '&uuid=' + uuid.toString();
+                if (code != undefined) {
+                    reply_url += '&code=' + code.toString();
+                }
+                if (info != undefined) {
+                    reply_url += '&info=' + info.toString();
+                }
+                reply.redirect(reply_url);
+            }
+            else {
+                // reply(results.success + ': ' + uuid);
+                reply(//results.success + 
+                firstRow);
+            }
+
+        })
+            .catch(function (e) {
+            var message = e.message || '';
+            var stack = e.stack || '';
+            console.error(
+            // results.failure, 
+            message, stack);
+            reply(results.failure + message).code(500);
+        });
+    };
+	
 	PostgresQueries.prototype.dbExecuteCarpoolAPIFunction = function (payload, pool, fnExecuteFunctionString, fnPayloadArray, req, reply, results) {
         var queryString = fnExecuteFunctionString();
         console.log("executeFunctionString: " + queryString);

--- a/nodeAppPostPg/routeFunctions.js
+++ b/nodeAppPostPg/routeFunctions.js
@@ -68,7 +68,8 @@ function createPostFn(resultStringText, dbQueryFn, payloadFn, logFn) {
         else {
             logPost(req);
         }
-        postgresQueries.dbExecuteCarpoolAPIFunction(payload, rfPool, dbQueryFn, payloadFn, req, reply, results);
+        // postgresQueries.dbExecuteCarpoolAPIFunction(payload, rfPool, dbQueryFn, payloadFn, req, reply, results);
+        postgresQueries.dbExecuteCarpoolAPIFunction_Insert(payload, rfPool, dbQueryFn, payloadFn, req, reply, results);
     }
     return postFn;
 }


### PR DESCRIPTION
This PR patches the recent db/nodeapp changes so that the app behaves as expected (the docker readme changes aren't relevant here and can be ignored)

@richardwestenra @dmilet could we review this PR and clarify that how it works is as planned, please? 

The recent changes to the db and nodeapp have impacted the redirect handling for both riders and drivers. This PR restores the original behaviour. The thanks-driver/rider pages are also provided with extra querystring info about the success of the db action.

In more detail:

The carpool-vote need-ride/offer-ride pages contain a form redirect of this pattern:
.../thanks-rider/?type=rider

The node app appends the uuid to the redirect (as before) and now also a status code and error/info text(if any), then executes the redirect:
e.g.
.../thanks-driver/?type=driver&uuid=e9be4d0b-f7e6-47b2-a300-66d7bcf5875c&code=0&info=

The code in this PR passes all my tests on my docker set-up. The redirect to the thanks pages work correctly. The links on the thanks pages go to the self service page where the user is able to login and see their information.