### PR TITLE
Add url to make documentation easier to understand

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -78,6 +78,9 @@ sh ./specific-machine-local-frontend.sh cp-pg-server R https://github.com/voteam
 sh ./start-compose-local-frontend.sh
 ```
 
+Awesome, you are up and running! Head to http://localhost:4000 in your browser to see the running app.
+
+##### Stopping & cleaning up the environment
 Ctrl-C to finish, then tidy up with this command
 ```
 docker-compose -f ./compose/full-stack-local/docker-compose-local-frontend.yml down


### PR DESCRIPTION
Quite straightforward, add the link to http://localhost:4000 so people don't have to dig into the source code or logs to see which port they need to access to view the running environment.