### PR TITLE
Resolve issue with travis tests and jekyll permissions

### DIFF
--- a/docker/compose-tests.sh
+++ b/docker/compose-tests.sh
@@ -66,6 +66,8 @@ cat cp-front-end-stdout.log | grep 'Server running'
 cat cp-front-end-stdout.log | grep 'Configuration file'
 cat cp-front-end-stdout.log | grep 'Source'
 cat cp-front-end-stdout.log | grep 'Destination'
+cat cp-front-end-stdout.log
+cat cp-front-end-stderr.log
 
 echo sct-travis sleep 10
 sleep 10

--- a/docker/compose-tests.sh
+++ b/docker/compose-tests.sh
@@ -76,9 +76,6 @@ echo sct-travis pg-client status
 docker logs fullstacktest_cp-client_1 > cp-client-stdout.log 2>cp-pg-client-stderr.log
 cat cp-client-stdout.log | grep 'DO'
 
-echo sct-travis sleep 60
-sleep 60
-
 echo sct-travis curl status
 
 # curl 10.5.0.6:5432

--- a/docker/compose-tests.sh
+++ b/docker/compose-tests.sh
@@ -74,6 +74,11 @@ echo sct-travis pg-client status
 docker logs fullstacktest_cp-client_1 > cp-client-stdout.log 2>cp-pg-client-stderr.log
 cat cp-client-stdout.log | grep 'DO'
 
+echo sct-travis sleep 60
+sleep 60
+
+echo sct-travis curl status
+
 # curl 10.5.0.6:5432
 curl 10.5.0.5:8000
 curl 10.5.0.4:4000 | grep "Every American"

--- a/docker/jekyll/Dockerfile
+++ b/docker/jekyll/Dockerfile
@@ -23,6 +23,9 @@ RUN git clone --single-branch --branch $BRANCH_NAME $REPO frontend \
 
 WORKDIR $FE_PATH
 
+# give jekyll permission to create _site in this folder
+RUN chown -R jekyll $FE_PATH
+
 RUN pwd
 RUN ls
 


### PR DESCRIPTION
Probably due to the recent travis change of the default Linux build, the travis tests are failing due to jekyll errors. This change provides jekyll with the necessary permissions to create the `_site` folder