### PR TITLE
rename constant to refer to tb_user instead of operator

### DIFF
--- a/nodeAppPostPg/DbDefsTables.js
+++ b/nodeAppPostPg/DbDefsTables.js
@@ -12,7 +12,7 @@ class DbDefsTables {
         this.RIDER_TABLE = 'rider';
         this.HELPER_TABLE = 'helper';
         this.MATCH_TABLE = 'match';
-        this.USER_TABLE = 'operator';
+        this.USER_TABLE = 'tb_user';
     }
 }
 exports.DbDefsTables = DbDefsTables;

--- a/nodeAppPostPg/DbDefsTables.ts
+++ b/nodeAppPostPg/DbDefsTables.ts
@@ -9,7 +9,7 @@ class DbDefsTables {
   readonly RIDER_TABLE: string   = 'rider';
   readonly HELPER_TABLE: string  = 'helper';
   readonly MATCH_TABLE: string   = 'match';
-  readonly USER_TABLE: string   = 'operator';
+  readonly USER_TABLE: string   = 'tb_user';
 }
 
 class DbDefsViews {

--- a/nodeAppPostPg/DbQueriesPosts.js
+++ b/nodeAppPostPg/DbQueriesPosts.js
@@ -87,8 +87,8 @@ class DbQueriesPosts {
         /*
         email character varying,
         username character varying,
-        userpassword character varying,
-        userIsAdmin boolean
+        password character varying,
+        is_admin boolean
         */
     }
 }

--- a/nodeAppPostPg/DbQueriesPosts.ts
+++ b/nodeAppPostPg/DbQueriesPosts.ts
@@ -100,8 +100,8 @@ class DbQueriesPosts {
     /*	
     email character varying,
     username character varying,
-    userpassword character varying,
-    userIsAdmin boolean
+    password character varying,
+    is_admin boolean
     */
   }
 }


### PR DESCRIPTION
Changes so node app works with #207 

@dmilet the node app still refers to `tb_user.is_admin` as `tb_user.admin` 