### PR TITLE
Db changes plus development and test support for operator page users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ before_script:
 # https://stackoverflow.com/questions/10516201/updating-file-permissions-only-in-git
 # https://stackoverflow.com/questions/14267441/automatically-apply-git-update-index-chmodx-to-executable-files
 script:
-  - travis_retry ./compose-tests.sh pause-cancel2
+  # - travis_retry ./compose-tests.sh pause-cancel2
+  - travis_retry ./compose-tests.sh full-tests
 
 after_script:
   - docker-compose -f ./compose/full-stack-test/docker-compose-test.yml down

--- a/db/carpool_schema.sql
+++ b/db/carpool_schema.sql
@@ -77,7 +77,7 @@ CREATE TABLE tb_user (
     email character varying(250) NOT NULL,
     username character varying(250) NOT NULL,
     password character varying(250) NOT NULL,
-    admin boolean DEFAULT FALSE NOT NULL,
+    is_admin boolean DEFAULT FALSE NOT NULL,
     "UUID_organization" character varying(50)
 );
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -218,8 +218,6 @@ sh ./start-compose-tests-fullstack.sh
 sh ./start-compose-tests-fullstack.sh match
 ```
 
-docker-compose -f ./compose/full-stack-test/docker-compose-test-fullstack.yml
-
 ## Common development tasks
 
 ### 1) Create a front-end PR that requires changes to tests

--- a/docker/README.md
+++ b/docker/README.md
@@ -139,6 +139,8 @@ There are three types of tests, depending on whether it is required to override 
 
 The app, under the test setups, does not execute correctly in the standard browser. Instead, use a VNC viewer (e.g. [RealVNC](https://www.realvnc.com/download/viewer/)) to watch the test being executed on vnc://localhost:5900 (don't type vnc:// for RealVNC viewer)
 
+Password requested is set by `selenium/standalone-chrome-debug` and is `secret`.
+
 ### 1) Github repos only - ignores any local code
 
 #### Go to the docker folder ...

--- a/docker/compose/full-stack-local/docker-compose-local-fullstack.yml
+++ b/docker/compose/full-stack-local/docker-compose-local-fullstack.yml
@@ -63,7 +63,7 @@ services:
     environment:
       - PGPASSWORD=pwd
       - PGHOST=10.4.0.6
-      - JWT_SECRET=secret
+      - JWT_SECRET=test_weak_secret
     ports:
       - '8000:8000'
       - '5858:5858'

--- a/docker/compose/full-stack-test/docker-compose-test-fullstack.yml
+++ b/docker/compose/full-stack-test/docker-compose-test-fullstack.yml
@@ -65,6 +65,7 @@ services:
 
       - PGPASSWORD=pwd
       - PGHOST=10.5.0.6
+      - JWT_SECRET=test_weak_secret
     ports:
       - "8000:8000"
     links:

--- a/docker/compose/full-stack-test/docker-compose-test.yml
+++ b/docker/compose/full-stack-test/docker-compose-test.yml
@@ -56,6 +56,7 @@ services:
     environment:
       - PGPASSWORD=pwd
       - PGHOST=10.5.0.6
+      - JWT_SECRET=test_weak_secret
     ports:
       - "8000:8000"
     links:

--- a/docker/jekyllDev/Dockerfile
+++ b/docker/jekyllDev/Dockerfile
@@ -44,6 +44,9 @@ COPY ./_config-local-ip.yml /
 COPY ./expo-start.sh /
 RUN chmod +x /expo-start.sh
 
+RUN echo "expo-start.sh"
+RUN more /expo-start.sh
+
 # ENTRYPOINT ["jekyll serve -H 0.0.0.0 --watch --config _config-dev.yml"]
 # ENTRYPOINT [""]
 # ENTRYPOINT ["/bin/bash"]

--- a/docker/jekyllDev/_config-local-host.yml
+++ b/docker/jekyllDev/_config-local-host.yml
@@ -1,2 +1,3 @@
 api: "http://localhost:8000"
 cp_site: "http://localhost:4000"
+webpack_bundle: "bundle"

--- a/docker/jekyllDev/_config-local-ip.yml
+++ b/docker/jekyllDev/_config-local-ip.yml
@@ -1,2 +1,3 @@
 api: "http://10.5.0.5:8000"
 cp_site: "http://10.5.0.4:4000"
+webpack_bundle: "bundle"

--- a/docker/jekyllDev/expo-start.sh
+++ b/docker/jekyllDev/expo-start.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+echo 'expo-start'
+
 jekyll serve -H 0.0.0.0 --force_polling --source /usr/src/app/frontend --destination /usr/src/app/frontend/_site --config /_config-local-host.yml &
 # run webpack as background task
-webpack --watch --progress --info-verbosity verbose &
+webpack --watch --progress --info-verbosity verbose --config development-webpack.config.js &
+
+webpack --watch --progress --info-verbosity verbose --config production-webpack.config.js &
 
 /bin/bash

--- a/docker/nodeApp/Dockerfile
+++ b/docker/nodeApp/Dockerfile
@@ -41,6 +41,7 @@ RUN git merge origin/$BRANCH_NAME
 
 RUN cd /usr/src/app/backend/nodeAppPostPg
 
+RUN npm -v 
 RUN npm install 
 RUN npm install -g typescript
 

--- a/docker/pg-auto/create_fresh_carpool_db2.sh
+++ b/docker/pg-auto/create_fresh_carpool_db2.sh
@@ -26,3 +26,4 @@ psql < carpool_roles.sql \
 && psql $DB < fct_user_actions.sql \
 && psql $DB < fct_matching_engine.sql \
 && psql $DB < /usr/src/app/backend/docker/pg-auto/alter.sql \
+&& psql $DB < /usr/src/app/backend/docker/pg-auto/test-user.sql \

--- a/docker/pg-auto/test-user.sql
+++ b/docker/pg-auto/test-user.sql
@@ -1,0 +1,2 @@
+INSERT INTO carpoolvote.tb_user (email, username, password, admin)
+    VALUES ('e@t.com', 'test', 'abc', false);

--- a/docker/pg-auto/test-user.sql
+++ b/docker/pg-auto/test-user.sql
@@ -1,2 +1,2 @@
-INSERT INTO carpoolvote.tb_user (email, username, password, admin)
-    VALUES ('e@t.com', 'test', 'abc', false);
+INSERT INTO carpoolvote.tb_user (email, username, password, is_admin)
+    VALUES ('e@t.com', 'test', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', false);

--- a/docker/pg-auto/test-user.sql
+++ b/docker/pg-auto/test-user.sql
@@ -1,2 +1,4 @@
 INSERT INTO carpoolvote.tb_user (email, username, password, is_admin)
-    VALUES ('e@t.com', 'test', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', false);
+    VALUES ('admin@test.com', 'admin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', true);
+INSERT INTO carpoolvote.tb_user (email, username, password, is_admin)
+    VALUES ('notadmin@test.com', 'notadmin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', false);

--- a/nodeAppPostPg/DbQueriesPosts.js
+++ b/nodeAppPostPg/DbQueriesPosts.js
@@ -88,7 +88,7 @@ class DbQueriesPosts {
         email character varying,
         username character varying,
         password character varying,
-        admin boolean
+        is_admin boolean
         */
     }
 }

--- a/nodeAppPostPg/DbQueriesPosts.ts
+++ b/nodeAppPostPg/DbQueriesPosts.ts
@@ -101,7 +101,7 @@ class DbQueriesPosts {
     email character varying,
     username character varying,
     password character varying,
-    admin boolean
+    is_admin boolean
     */
   }
 }

--- a/nodeAppPostPg/login.js
+++ b/nodeAppPostPg/login.js
@@ -51,7 +51,6 @@ const verifyCredentials = async (req, res) => {
         console.log('verify credentials - bad secret');
         return res(Boom.badRequest(verifyCredentialsError));
     }
-    console.log('pwd', password);
     console.log('email', email);
     console.log('username', username);
     const userInfo = await routeFns.getUsersInternal(req, res, payload);

--- a/nodeAppPostPg/login.ts
+++ b/nodeAppPostPg/login.ts
@@ -62,7 +62,6 @@ const verifyCredentials = async (req, res) => {
     return res(Boom.badRequest(verifyCredentialsError));
   }
 
-  console.log('pwd', password);
   console.log('email', email);
   console.log('username', username);
 

--- a/nodeAppPostPg/testing/nightwatch/common/common.js
+++ b/nodeAppPostPg/testing/nightwatch/common/common.js
@@ -449,6 +449,14 @@ var testObject = {
         .viewDriverSelfService()
         .viewProposedMatch()
         .acceptMatch();
+  }),
+
+  'viewOperatorPage': createChainableTest(function(client) {
+    client
+      .url('http://10.5.0.4:4000/operator-page')
+      .pause(3000)
+      .waitForElementVisible('#manage', 1000)
+      .assert.containsText('#manage', 'MANAGE THE SYSTEM');
   })
 };
 

--- a/nodeAppPostPg/testing/nightwatch/common/common.js
+++ b/nodeAppPostPg/testing/nightwatch/common/common.js
@@ -482,7 +482,7 @@ var testObject = {
       .waitForElementVisible('#showGetDriversList', 3000) // info not shown for non-admin user
 
       .waitForElementVisible('#logout', 3000)
-      .click('#logout') // now the logout button
+      .click('#logout')
       .pause(3000)
       .expect.element('#root').text.to.not.contain('Welcome,');
 
@@ -504,11 +504,12 @@ var testObject = {
       .click('#hideGetDriversList')
       .pause(3000)
       .waitForElementVisible('#showGetDriversList', 3000)
-
-      // showGetDriversList
-      // hideGetDriversList
       .pause(3000)
 
+      .waitForElementVisible('#logout', 3000)
+      .click('#logout')
+      .pause(3000)
+      .expect.element('#root').text.to.not.contain('Welcome,');
 
     })
 };

--- a/nodeAppPostPg/testing/nightwatch/common/common.js
+++ b/nodeAppPostPg/testing/nightwatch/common/common.js
@@ -456,7 +456,8 @@ var testObject = {
       .url('http://10.5.0.4:4000/operator-page')
       .pause(3000)
       .waitForElementVisible('#manage', 1000)
-      .assert.containsText('#manage', 'MANAGE THE SYSTEM');
+      .assert.containsText('h1.bannerbox__title', 'MANAGE THE SYSTEM')
+      .assert.containsText('#manage', 'Welcome to the new operator admin page');
   })
 };
 

--- a/nodeAppPostPg/testing/nightwatch/common/common.js
+++ b/nodeAppPostPg/testing/nightwatch/common/common.js
@@ -457,7 +457,23 @@ var testObject = {
       .pause(3000)
       .waitForElementVisible('#manage', 1000)
       .assert.containsText('h1.bannerbox__title', 'MANAGE THE SYSTEM')
-      .assert.containsText('#manage', 'Welcome to the new operator admin page');
+      .assert.containsText('#manage', 'Welcome to the new operator admin page')
+      .setValue('#root #username', 'fail')
+      .setValue('#root #password', 'abc')
+      .click('#root button')
+      .pause(3000)
+      .expect.element('#root').text.to.not.contain('Welcome,');
+
+    client
+      .clearValue('#root #username')
+      .setValue('#root #username', 'test')
+
+      .clearValue('#root #password')
+      .setValue('#root #password', 'abc')
+      
+      .click('#root button')
+      .pause(3000)
+      .assert.containsText('#root', 'Welcome,')
   })
 };
 

--- a/nodeAppPostPg/testing/nightwatch/common/common.js
+++ b/nodeAppPostPg/testing/nightwatch/common/common.js
@@ -458,6 +458,7 @@ var testObject = {
       .waitForElementVisible('#manage', 1000)
       .assert.containsText('h1.bannerbox__title', 'MANAGE THE SYSTEM')
       .assert.containsText('#manage', 'Welcome to the new operator admin page')
+
       .setValue('#root #username', 'fail')
       .setValue('#root #password', 'abc')
       .click('#root button')
@@ -466,15 +467,50 @@ var testObject = {
 
     client
       .clearValue('#root #username')
-      .setValue('#root #username', 'test')
+      .setValue('#root #username', 'notadmin')
 
       .clearValue('#root #password')
       .setValue('#root #password', 'abc')
-      
+
       .click('#root button')
       .pause(3000)
       .assert.containsText('#root', 'Welcome,')
-  })
+
+      .waitForElementVisible('#showGetDriversList', 3000)
+      .click('#showGetDriversList')
+      .pause(3000)
+      .waitForElementVisible('#showGetDriversList', 3000) // info not shown for non-admin user
+
+      .waitForElementVisible('#logout', 3000)
+      .click('#logout') // now the logout button
+      .pause(3000)
+      .expect.element('#root').text.to.not.contain('Welcome,');
+
+    client
+      .clearValue('#root #username')
+      .setValue('#root #username', 'admin')
+
+      .clearValue('#root #password')
+      .setValue('#root #password', 'abc')
+
+      .click('#root button')
+      .pause(3000)
+      .assert.containsText('#root', 'Welcome,')
+
+      .waitForElementVisible('#showGetDriversList', 3000)
+      .click('#showGetDriversList')
+      .pause(3000)
+      .waitForElementVisible('#hideGetDriversList', 3000)
+      .click('#hideGetDriversList')
+      .pause(3000)
+      .waitForElementVisible('#showGetDriversList', 3000)
+
+      // showGetDriversList
+      // hideGetDriversList
+      .pause(3000)
+
+
+    })
 };
 
 module.exports = testObject;

--- a/nodeAppPostPg/testing/nightwatch/tests/full-tests/full-tests.js
+++ b/nodeAppPostPg/testing/nightwatch/tests/full-tests/full-tests.js
@@ -20,6 +20,8 @@ module.exports = {
       .viewRiderSelfService()
       .viewRiderMatch()
       .riderCancelMatch()
+      
+      .viewOperatorPage()
       .finish();
   }
 };

--- a/nodeAppPostPg/testing/nightwatch/tests/full-tests/full-tests.js
+++ b/nodeAppPostPg/testing/nightwatch/tests/full-tests/full-tests.js
@@ -1,0 +1,25 @@
+var common = require('../../common/common.js');
+
+module.exports = {
+  'full-match-pause': function (client) {
+
+    common.matchRiderDriver(client)
+      .driverCancelMatch()
+      
+      .nextDate()
+      .addDriver()
+      .viewDriverSelfService()
+      .pauseDriverSelfService()
+      .cancelDriverSelfService()
+      .addRider()
+      .viewRiderSelfService()
+      .cancelRiderSelfService()      
+
+      .nextDate()
+      .matchRiderDriver()
+      .viewRiderSelfService()
+      .viewRiderMatch()
+      .riderCancelMatch()
+      .finish();
+  }
+};


### PR DESCRIPTION
Changes `tb_user.admin` to `tb_user.is_admin`

Docker environments for fullstack development, local testing and `Travis` have an environment variable `JWT_TOKEN` with a test key. An admin and non-admin user are added automatically to these docker environments.

Operator page tests are added to the existing `nightwatch` tests and these are used by `Travis`. There are checks for an invalid user, a user without admin permission and an admin user, to ensure each user only can access the correct routes.

NOTE: the password mentioned in `README.md` below is for `VNC` viewer (for watching locally-run tests) and is not related to JWT in any way