### PR TITLE
Patch - apply recent changes related to webpack to test jekyll docker machine

### DIFF
--- a/docker/jekyll/_config-local-host.yml
+++ b/docker/jekyll/_config-local-host.yml
@@ -1,2 +1,3 @@
 api: "http://localhost:8000"
 cp_site: "http://localhost:4000"
+webpack_bundle: "bundle"

--- a/docker/jekyll/_config-local-ip.yml
+++ b/docker/jekyll/_config-local-ip.yml
@@ -1,2 +1,3 @@
 api: "http://10.5.0.5:8000"
 cp_site: "http://10.5.0.4:4000"
+webpack_bundle: "bundle"


### PR DESCRIPTION
The front end use of the webpack bundle has been updated. The changes in this PR are needed so that the operator page tests work with those front end changes

This PR will be merged once the automatic tests have run successfully