### PR TITLE
add secure routes for riders and matches admin queries

### DIFF
--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -32,9 +32,10 @@ module.exports = {
     dbRiderConfirmedMatchFunctionString: dbRiderConfirmedMatchFunctionString,
     dbGetMatchRiderQueryString: dbGetMatchRiderQueryString,
     dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
-    dbGetMatchesQueryString: dbGetMatchesQueryString,
+    dbGetMatchesQueryString,
     dbGetDriversQueryString,
-    dbGetUsersQueryString: dbGetUsersQueryString,
+    dbGetRidersQueryString,
+    dbGetUsersQueryString,
     dbAddUserQueryString,
     dbGetUnmatchedDriversQueryString: dbGetUnmatchedDriversQueryString,
     dbGetUnmatchedRidersQueryString: dbGetUnmatchedRidersQueryString,
@@ -90,6 +91,9 @@ function dbGetMatchesQueryString() {
 }
 function dbGetDriversQueryString() {
     return dbQueriesHelpers.dbSelectFromString(dbDefsSchema.SCHEMA_NAME, dbDefsTables.DRIVER_TABLE);
+}
+function dbGetRidersQueryString() {
+    return dbQueriesHelpers.dbSelectFromString(dbDefsSchema.SCHEMA_NAME, dbDefsTables.RIDER_TABLE);
 }
 function dbGetUsersQueryString() {
     return dbQueriesHelpers.dbSelectFromString(dbDefsSchema.SCHEMA_NAME, dbDefsTables.USER_TABLE);

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -41,10 +41,11 @@ module.exports = {
 
   dbGetMatchRiderQueryString: dbGetMatchRiderQueryString,
   dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
-  dbGetMatchesQueryString: dbGetMatchesQueryString,
 
+  dbGetMatchesQueryString,
   dbGetDriversQueryString,
-  dbGetUsersQueryString: dbGetUsersQueryString,
+  dbGetRidersQueryString,
+  dbGetUsersQueryString,
 
   dbAddUserQueryString,
 
@@ -158,6 +159,13 @@ function dbGetDriversQueryString(): string {
   return dbQueriesHelpers.dbSelectFromString(
     dbDefsSchema.SCHEMA_NAME,
     dbDefsTables.DRIVER_TABLE
+  );
+}
+
+function dbGetRidersQueryString(): string {
+  return dbQueriesHelpers.dbSelectFromString(
+    dbDefsSchema.SCHEMA_NAME,
+    dbDefsTables.RIDER_TABLE
   );
 }
 

--- a/nodeAppPostPg/index.js
+++ b/nodeAppPostPg/index.js
@@ -258,8 +258,28 @@ const getDriversListHandler = async (req, res) => {
     const driverInfoJSON = JSON.stringify(driverInfo);
     res({ data: driverInfoJSON });
 };
+const getRidersListHandler = async (req, res) => {
+    const payload = req.query;
+    const riderInfo = await routeFns.getRidersListInternal(req, res, payload);
+    if (!riderInfo) {
+        return res(Boom.badRequest('get riders list error'));
+    }
+    const riderInfoJSON = JSON.stringify(riderInfo);
+    res({ data: riderInfoJSON });
+};
+const getMatchesListHandler = async (req, res) => {
+    const payload = req.query;
+    const matchInfo = await routeFns.getMatchesListInternal(req, res, payload);
+    if (!matchInfo) {
+        return res(Boom.badRequest('get matches list error'));
+    }
+    const matchInfoJSON = JSON.stringify(matchInfo);
+    res({ data: matchInfoJSON });
+};
 const usersHandler = getUsersListHandler;
 const driversHandler = getDriversListHandler;
+const ridersHandler = getRidersListHandler;
+const matchesHandler = getMatchesListHandler;
 server.register([
     {
         register: hapiAuthJwt,
@@ -312,6 +332,28 @@ server.register([
             path: '/drivers/list',
             config: {
                 handler: driversHandler,
+                auth: {
+                    strategy: 'jwt',
+                    scope: ['admin']
+                }
+            }
+        });
+        server.route({
+            method: 'GET',
+            path: '/riders/list',
+            config: {
+                handler: ridersHandler,
+                auth: {
+                    strategy: 'jwt',
+                    scope: ['admin']
+                }
+            }
+        });
+        server.route({
+            method: 'GET',
+            path: '/matches/list',
+            config: {
+                handler: matchesHandler,
                 auth: {
                     strategy: 'jwt',
                     scope: ['admin']

--- a/nodeAppPostPg/index.ts
+++ b/nodeAppPostPg/index.ts
@@ -358,8 +358,38 @@ const getDriversListHandler = async (req, res) => {
   res({ data: driverInfoJSON });
 };
 
+const getRidersListHandler = async (req, res) => {
+  const payload = req.query;
+
+  const riderInfo = await routeFns.getRidersListInternal(req, res, payload);
+
+  if (!riderInfo) {
+    return res(Boom.badRequest('get riders list error'));
+  }
+
+  const riderInfoJSON = JSON.stringify(riderInfo);
+
+  res({ data: riderInfoJSON });
+};
+
+const getMatchesListHandler = async (req, res) => {
+  const payload = req.query;
+
+  const matchInfo = await routeFns.getMatchesListInternal(req, res, payload);
+
+  if (!matchInfo) {
+    return res(Boom.badRequest('get matches list error'));
+  }
+
+  const matchInfoJSON = JSON.stringify(matchInfo);
+
+  res({ data: matchInfoJSON });
+};
+
 const usersHandler = getUsersListHandler;
 const driversHandler = getDriversListHandler;
+const ridersHandler = getRidersListHandler;
+const matchesHandler = getMatchesListHandler;
 
 server.register(
   [
@@ -419,6 +449,30 @@ server.register(
         path: '/drivers/list',
         config: {
           handler: driversHandler,
+          auth: {
+            strategy: 'jwt',
+            scope: ['admin']
+          }
+        }
+      });
+
+      server.route({
+        method: 'GET',
+        path: '/riders/list',
+        config: {
+          handler: ridersHandler,
+          auth: {
+            strategy: 'jwt',
+            scope: ['admin']
+          }
+        }
+      });
+
+      server.route({
+        method: 'GET',
+        path: '/matches/list',
+        config: {
+          handler: matchesHandler,
           auth: {
             strategy: 'jwt',
             scope: ['admin']

--- a/nodeAppPostPg/routeFunctions.js
+++ b/nodeAppPostPg/routeFunctions.js
@@ -76,6 +76,24 @@ async function getDriversListInternal(req, reply, payload) {
     const dbData = await postgresQueries.dbGetDataListInternal(rfPool, dbQueries.dbGetDriversQueryString, reply, results);
     return dbData;
 }
+async function getRidersListInternal(req, reply, payload) {
+    var results = {
+        success: 'GET riders list internal: ',
+        failure: 'GET riders list internal error: '
+    };
+    req.log();
+    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, dbQueries.dbGetRidersQueryString, reply, results);
+    return dbData;
+}
+async function getMatchesListInternal(req, reply, payload) {
+    var results = {
+        success: 'GET matches list internal: ',
+        failure: 'GET matches list internal error: '
+    };
+    req.log();
+    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, dbQueries.dbGetMatchesQueryString, reply, results);
+    return dbData;
+}
 async function addUserInternal(req, reply, payload) {
     var results = {
         success: 'POST user internal: ',
@@ -297,6 +315,8 @@ module.exports = {
     getUsersInternal,
     getUsersListInternal,
     getDriversListInternal,
+    getRidersListInternal,
+    getMatchesListInternal,
     addUserInternal,
     getUnmatchedDrivers: getUnmatchedDrivers,
     getDriversDetails: getDriversDetails,

--- a/nodeAppPostPg/routeFunctions.ts
+++ b/nodeAppPostPg/routeFunctions.ts
@@ -138,6 +138,42 @@ async function getDriversListInternal(req: any, reply: any, payload: UserType) {
   return dbData;
 }
 
+async function getRidersListInternal(req: any, reply: any, payload: UserType) {
+  var results = {
+    success: 'GET riders list internal: ',
+    failure: 'GET riders list internal error: '
+  };
+
+  req.log();
+
+  const dbData = await postgresQueries.dbGetDataListInternal(
+    rfPool,
+    dbQueries.dbGetRidersQueryString,
+    reply,
+    results
+  );
+
+  return dbData;
+}
+
+async function getMatchesListInternal(req: any, reply: any, payload: UserType) {
+  var results = {
+    success: 'GET matches list internal: ',
+    failure: 'GET matches list internal error: '
+  };
+
+  req.log();
+
+  const dbData = await postgresQueries.dbGetDataListInternal(
+    rfPool,
+    dbQueries.dbGetMatchesQueryString,
+    reply,
+    results
+  );
+
+  return dbData;
+}
+
 async function addUserInternal(req: any, reply: any, payload: [any]) {
   var results = {
     success: 'POST user internal: ',
@@ -561,6 +597,8 @@ module.exports = {
   getUsersInternal,
   getUsersListInternal,
   getDriversListInternal,
+  getRidersListInternal,
+  getMatchesListInternal,
   addUserInternal,
 
   getUnmatchedDrivers: getUnmatchedDrivers,


### PR DESCRIPTION
@dmilet nothing fundamentally new here, just adding two secure routes (for riders and matches) to provide that info to the front-end operators page