### PR TITLE
support for storing organization choice for new riders and drivers

### DIFF
--- a/db/carpool_schema.sql
+++ b/db/carpool_schema.sql
@@ -763,3 +763,8 @@ GRANT ALL ON TABLE organization TO carpool_role;
 -- PostgreSQL database dump complete
 --
 
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('None');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('NAACP');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('AAPD');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('PPC');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('MDCC');

--- a/db/carpool_schema.sql
+++ b/db/carpool_schema.sql
@@ -749,6 +749,17 @@ GRANT ALL ON TABLE zip_codes TO carpool_role;
 
 
 --
+-- Name: organization; Type: ACL; Schema: carpoolvote; Owner: carpool_admins
+--
+
+REVOKE ALL ON TABLE organization FROM PUBLIC;
+REVOKE ALL ON TABLE organization FROM carpool_admins;
+GRANT SELECT ON TABLE organization TO carpool_web_role;
+GRANT ALL ON TABLE organization TO carpool_admins;
+GRANT ALL ON TABLE organization TO carpool_role;
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/db/deploy_org_changes.sql
+++ b/db/deploy_org_changes.sql
@@ -1,0 +1,14 @@
+--
+-- Name: organization; Type: ACL; Schema: carpoolvote; Owner: carpool_admins
+--
+REVOKE ALL ON TABLE organization FROM PUBLIC;
+REVOKE ALL ON TABLE organization FROM carpool_admins;
+GRANT SELECT ON TABLE organization TO carpool_web_role;
+GRANT ALL ON TABLE organization TO carpool_admins;
+GRANT ALL ON TABLE organization TO carpool_role;
+
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('None');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('NAACP');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('AAPD');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('PPC');
+INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('MDCC');

--- a/db/deploy_org_fn_changes.sql
+++ b/db/deploy_org_fn_changes.sql
@@ -1,0 +1,440 @@
+-- 
+-- submit_new_rider
+-- return codes : 
+-- -1 : ERROR - Generic Error
+-- 0  : SUCCESS
+-- 1  : ERROR - Input is disabled
+-- 2  : ERROR - Input validation
+CREATE OR REPLACE FUNCTION carpoolvote.submit_new_rider(
+	a_IPAddress character varying,
+    a_RiderFirstName character varying,
+    a_RiderLastName character varying,
+    a_RiderEmail character varying,
+    a_RiderPhone character varying,
+    a_RiderCollectionZIP character varying,
+    a_RiderDropOffZIP character varying,
+    a_AvailableRideTimesLocal character varying,
+    a_TotalPartySize integer,
+    a_TwoWayTripNeeded boolean,
+    a_RiderIsVulnerable boolean,
+    a_RiderWillNotTalkPolitics boolean,
+    a_PleaseStayInTouch boolean,
+    a_NeedWheelchair boolean,
+    a_RiderPreferredContact character varying,
+    a_RiderAccommodationNotes character varying,
+    a_RiderLegalConsent boolean,
+    a_RiderWillBeSafe boolean,
+	a_RiderCollectionStreetNumber character varying,
+    a_RiderCollectionAddress character varying,
+    a_RiderDestinationAddress character varying,
+	a_RidingOnBehalfOfOrganization boolean,
+	a_RidingOBOOrganizationName character varying,
+	OUT out_uuid character varying,
+	OUT out_error_code INTEGER,
+	OUT out_error_text TEXT) AS
+$BODY$
+DECLARE
+	v_step character varying(200);
+	ride_times_rider text[];
+	b_rider_all_times_expired  boolean := TRUE;
+	rider_time text;
+	start_ride_time timestamp without time zone;
+	end_ride_time timestamp without time zone;
+    uuid_organization character varying(50);
+
+	a_ip inet;
+BEGIN	
+
+	out_uuid := '';
+	out_error_code := carpoolvote.f_SUCCESS();
+	out_error_text := '';
+
+	BEGIN
+		v_step := 'S1';
+		IF  LOWER(COALESCE(carpoolvote.get_param_value('input.rider.enabled'), 'false')) = LOWER('false')
+		THEN
+			out_error_code := carpoolvote.f_INPUT_DISABLED();
+			out_error_text := 'Submission of new Rider is disabled.';
+			RETURN;
+		END IF;
+	
+		v_step := 'S2';
+		BEGIN
+			SELECT inet(a_IPAddress) into a_ip;
+		EXCEPTION WHEN invalid_text_representation
+		THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid IPAddress: ' || a_IPAddress;
+			RETURN;
+		END;
+		
+		v_step := 'S3';
+		SELECT * FROM carpoolvote.validate_availabletimeslocal(a_AvailableRideTimesLocal) into out_error_code, out_error_text;
+		IF out_error_code <> 0
+		THEN
+			RETURN;
+		END IF;
+
+	
+		-- zip code verification
+		v_step := 'S4';
+		IF NOT EXISTS
+			(SELECT 1 FROM carpoolvote.zip_codes z where z.zip = a_RiderCollectionZIP AND z.latitude_numeric IS NOT NULL AND z.longitude_numeric IS NOT NULL)
+		THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid/Not Found RiderCollectionZIP:' || a_RiderCollectionZIP;
+			RETURN;
+		END IF;
+
+		v_step := 'S5';
+		IF NOT EXISTS 
+			(SELECT 1 FROM carpoolvote.zip_codes z WHERE z.zip = a_RiderDropOffZIP AND z.latitude_numeric IS NOT NULL AND z.longitude_numeric IS NOT NULL)
+		THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid/Not Found RiderDropOffZIP:' || a_RiderDropOffZIP;
+			RETURN;
+		END IF;	
+	
+		v_step := 'S6';
+		IF (a_TotalPartySize is null) or (a_TotalPartySize <= 0) THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid TotalPartySize: ' || a_TotalPartySize;
+			RETURN;
+		END IF;
+
+		v_step := 'S7';
+		IF a_RidingOnBehalfOfOrganization IS NOT NULL and a_RidingOnBehalfOfOrganization IS TRUE
+		THEN 
+			IF a_RidingOBOOrganizationName IS NOT NULL and EXISTS (SELECT 1 FROM carpoolvote.organization o WHERE o."OrganizationName" = a_RidingOBOOrganizationName)
+			THEN
+				SELECT "UUID" FROM carpoolvote.organization o WHERE o."OrganizationName" = a_RidingOBOOrganizationName into uuid_organization;
+			ELSE
+				IF a_RidingOBOOrganizationName IS NULL 
+				THEN
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Invalid RidingOBOOrganizationName';
+					RETURN;
+				ELSE 
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Not Found RidingOBOOrganizationName:' || a_RidingOBOOrganizationName;
+					RETURN;
+				END IF;
+			END IF;
+		END IF;	
+
+		
+		v_step := 'S8';
+		out_uuid := carpoolvote.gen_random_uuid();
+		INSERT INTO carpoolvote.rider(
+		"UUID", "IPAddress", "RiderFirstName", "RiderLastName", "RiderEmail", "RiderPhone", "RiderCollectionZIP",
+		"RiderDropOffZIP", "AvailableRideTimesLocal", "TotalPartySize", "TwoWayTripNeeded", "RiderIsVulnerable",
+		"RiderWillNotTalkPolitics", "PleaseStayInTouch", "NeedWheelchair", "RiderPreferredContact",
+		"RiderAccommodationNotes", "RiderLegalConsent", "RiderWillBeSafe", "RiderCollectionStreetNumber", "RiderCollectionAddress", "RiderDestinationAddress", "uuid_organization")
+		VALUES (
+		out_uuid, a_IPAddress, a_RiderFirstName, a_RiderLastName, a_RiderEmail, a_RiderPhone, a_RiderCollectionZIP,
+		a_RiderDropOffZIP, a_AvailableRideTimesLocal, a_TotalPartySize, a_TwoWayTripNeeded, a_RiderIsVulnerable,
+		a_RiderWillNotTalkPolitics, a_PleaseStayInTouch, a_NeedWheelchair, a_RiderPreferredContact,
+		a_RiderAccommodationNotes, a_RiderLegalConsent, a_RiderWillBeSafe, a_RiderCollectionStreetNumber, a_RiderCollectionAddress, a_RiderDestinationAddress, uuid_organization);
+
+		v_step := 'S9';
+		SELECT * FROM carpoolvote.notify_new_rider(out_uuid) INTO out_error_code, out_error_text;
+		
+		RETURN;
+	EXCEPTION WHEN OTHERS
+	THEN
+		out_uuid := '';
+		out_error_code := carpoolvote.f_EXECUTION_ERROR();
+		out_error_text := 'Unexpected exception in submit_new_rider, ' || v_step ||  ' (' || SQLSTATE || ')' || SQLERRM;
+		RETURN;
+	END;
+	
+
+	
+END  
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+ALTER FUNCTION carpoolvote.submit_new_rider(character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying, character varying,
+    character varying,out character varying, out integer, out text)
+  OWNER TO carpool_admins;
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider(	character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying, character varying,
+    character varying,out character varying, out integer, out text) TO carpool_web_role;
+	
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider( character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying, character varying,
+    character varying,out character varying, out integer, out text) TO carpool_role;
+
+
+-- 
+-- submit_new_rider
+-- return codes : 
+-- -1 : ERROR - Generic Error
+-- 0  : SUCCESS
+-- 1  : ERROR - Input is disabled
+-- 2  : ERROR - Input validation
+CREATE OR REPLACE FUNCTION carpoolvote.submit_new_rider(
+	a_IPAddress character varying,
+    a_RiderFirstName character varying,
+    a_RiderLastName character varying,
+    a_RiderEmail character varying,
+    a_RiderPhone character varying,
+    a_RiderCollectionZIP character varying,
+    a_RiderDropOffZIP character varying,
+    a_AvailableRideTimesLocal character varying,
+    a_TotalPartySize integer,
+    a_TwoWayTripNeeded boolean,
+    a_RiderIsVulnerable boolean,
+    a_RiderWillNotTalkPolitics boolean,
+    a_PleaseStayInTouch boolean,
+    a_NeedWheelchair boolean,
+    a_RiderPreferredContact character varying,
+    a_RiderAccommodationNotes character varying,
+    a_RiderLegalConsent boolean,
+    a_RiderWillBeSafe boolean,
+    a_RiderCollectionAddress character varying,
+    a_RiderDestinationAddress character varying,
+	a_RidingOnBehalfOfOrganization boolean,
+	a_RidingOBOOrganizationName character varying,
+	OUT out_uuid character varying,
+	OUT out_error_code INTEGER,
+	OUT out_error_text TEXT) AS
+$BODY$
+BEGIN	
+
+SELECT * FROM carpoolvote.submit_new_rider(
+	a_IPAddress,
+    a_RiderFirstName,
+    a_RiderLastName,
+    a_RiderEmail,
+    a_RiderPhone,
+    a_RiderCollectionZIP,
+    a_RiderDropOffZIP,
+    a_AvailableRideTimesLocal,
+    a_TotalPartySize,
+    a_TwoWayTripNeeded,
+    a_RiderIsVulnerable,
+    a_RiderWillNotTalkPolitics,
+    a_PleaseStayInTouch,
+    a_NeedWheelchair,
+    a_RiderPreferredContact,
+    a_RiderAccommodationNotes,
+    a_RiderLegalConsent,
+    a_RiderWillBeSafe,
+	NULL,  -- the street number
+    a_RiderCollectionAddress,
+    a_RiderDestinationAddress,
+	a_RidingOnBehalfOfOrganization,
+	a_RidingOBOOrganizationName) INTO
+	out_uuid,
+	out_error_code,
+	out_error_text;
+	
+	RETURN;
+	
+END  
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+ALTER FUNCTION carpoolvote.submit_new_rider(character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying,
+    character varying,out character varying, out integer, out text)
+  OWNER TO carpool_admins;
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider(	character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying,
+    character varying,out character varying, out integer, out text) TO carpool_web_role;
+	
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider( character varying,
+    character varying, character varying,
+    character varying, character varying, character varying, character varying,
+    character varying, integer, boolean, boolean, boolean, boolean, boolean,
+    character varying, character varying, boolean, boolean, character varying,
+    character varying,out character varying, out integer, out text) TO carpool_role;
+	
+
+-- 
+-- 
+-- submit_new_driver
+-- return codes : 
+-- -1 : ERROR - Generic Error
+-- 0  : SUCCESS
+-- 1  : ERROR - Input is disabled
+-- 2  : ERROR - Input validation
+CREATE OR REPLACE FUNCTION carpoolvote.submit_new_driver(
+	a_IPAddress character varying,
+	a_DriverCollectionZIP character varying,
+	a_DriverCollectionRadius integer,
+	a_AvailableDriveTimesLocal character varying,
+	a_DriverCanLoadRiderWithWheelchair boolean,
+	a_SeatCount integer,
+	a_DriverLicenseNumber character varying,
+	a_DriverFirstName character varying,
+	a_DriverLastName character varying,
+	a_DriverEmail character varying,
+	a_DriverPhone character varying,
+	a_DrivingOnBehalfOfOrganization boolean,
+	a_DrivingOBOOrganizationName character varying,
+	a_RidersCanSeeDriverDetails boolean,
+	a_DriverWillNotTalkPolitics boolean,
+	a_PleaseStayInTouch boolean,
+	a_DriverPreferredContact character varying,
+	a_DriverWillTakeCare boolean,
+	OUT out_uuid character varying,
+	OUT out_error_code INTEGER,
+	OUT out_error_text TEXT) AS
+$BODY$
+DECLARE
+	v_step character varying(200);
+    uuid_organization character varying(50);
+	
+	a_ip inet;
+BEGIN	
+	
+	out_uuid := '';
+	out_error_code := 0;
+	out_error_text := '';
+	
+	BEGIN
+
+		v_step := 'S1';
+		IF  LOWER(COALESCE(carpoolvote.get_param_value('input.driver.enabled'), 'false')) = LOWER('false')
+		THEN
+			out_error_code := carpoolvote.f_INPUT_DISABLED();
+			out_error_text := 'Submission of new Driver is disabled.';
+			RETURN;
+		END IF;
+
+		v_step := 'S2';
+		BEGIN
+			SELECT inet(a_IPAddress) into a_ip;
+		EXCEPTION WHEN invalid_text_representation
+		THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid IPAddress: ' || a_IPAddress;
+			RETURN;
+		END;
+		
+		v_step := 'S3';
+		IF NOT EXISTS 
+			(SELECT 1 FROM carpoolvote.zip_codes z where z.zip = a_DriverCollectionZIP AND z.latitude_numeric IS NOT NULL AND z.longitude_numeric IS NOT NULL)
+		THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid/Not Found DriverCollectionZIP:' || a_DriverCollectionZIP;
+			RETURN;
+		END IF; 	
+
+		v_step := 'S4';
+		SELECT * FROM carpoolvote.validate_availabletimeslocal(a_AvailableDriveTimesLocal) into out_error_code, out_error_text;
+		IF out_error_code <> 0
+		THEN
+			RETURN;
+		END IF;
+		
+		v_step := 'S5';
+		IF (a_DriverCollectionRadius is null) or (a_DriverCollectionRadius <= 0) 
+		or (COALESCE(carpoolvote.get_param_value('radius.max'), '100')::int < a_DriverCollectionRadius) THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid DriverCollectionRadius';
+			RETURN;
+		END IF;
+
+		v_step := 'S6';
+		IF (a_SeatCount is null) or (a_SeatCount <= 0) THEN
+			out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+			out_error_text := 'Invalid SeatCount';
+			RETURN;
+		END IF;
+		
+		v_step := 'S7';
+		IF a_DrivingOnBehalfOfOrganization IS NOT NULL and a_DrivingOnBehalfOfOrganization IS TRUE
+		THEN 
+			IF a_DrivingOBOOrganizationName IS NOT NULL and EXISTS (SELECT 1 FROM carpoolvote.organization o WHERE o."OrganizationName" = a_DrivingOBOOrganizationName)
+			THEN
+				SELECT "UUID" FROM carpoolvote.organization o WHERE o."OrganizationName" = a_DrivingOBOOrganizationName into uuid_organization;
+			ELSE
+				IF a_DrivingOBOOrganizationName IS NULL 
+				THEN
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Invalid DrivingOBOOrganizationName';
+					RETURN;
+				ELSE 
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Not Found DrivingOBOOrganizationName:' || a_DrivingOBOOrganizationName;
+					RETURN;
+				END IF;
+			END IF;
+		END IF;	
+		
+		
+		v_step := 'S8';
+		out_uuid := carpoolvote.gen_random_uuid();
+		INSERT INTO carpoolvote.driver(
+		"UUID", "IPAddress", "DriverCollectionZIP", "DriverCollectionRadius", "AvailableDriveTimesLocal", 
+		"DriverCanLoadRiderWithWheelchair", "SeatCount", "DriverLicenseNumber", 
+		"DriverFirstName", "DriverLastName", "DriverEmail", "DriverPhone",
+		"DrivingOnBehalfOfOrganization", "DrivingOBOOrganizationName", "RidersCanSeeDriverDetails",
+		"DriverWillNotTalkPolitics", "PleaseStayInTouch", "DriverPreferredContact", "DriverWillTakeCare", "uuid_organization")
+		VALUES (
+		out_uuid, 
+		a_IPAddress, a_DriverCollectionZIP, a_DriverCollectionRadius, a_AvailableDriveTimesLocal, 
+		a_DriverCanLoadRiderWithWheelchair, a_SeatCount, a_DriverLicenseNumber, 
+		a_DriverFirstName, a_DriverLastName, a_DriverEmail, a_DriverPhone,
+		a_DrivingOnBehalfOfOrganization, a_DrivingOBOOrganizationName, a_RidersCanSeeDriverDetails,
+		a_DriverWillNotTalkPolitics, a_PleaseStayInTouch, a_DriverPreferredContact, a_DriverWillTakeCare, uuid_organization
+		);
+		
+		v_step := 'S9';
+		SELECT * FROM carpoolvote.notify_new_driver(out_uuid) INTO out_error_code, out_error_text;
+	
+		RETURN;
+	EXCEPTION WHEN OTHERS
+	THEN
+		out_uuid := '';
+		out_error_code := carpoolvote.f_EXECUTION_ERROR();
+		out_error_text := 'Unexpected exception in submit_new_driver, ' || v_step || ' (' || SQLSTATE || ')' || SQLERRM;
+		RETURN;
+	END;
+	
+
+	
+END  
+
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+ALTER FUNCTION carpoolvote.submit_new_driver(
+	character varying, character varying, integer, character varying,
+	boolean, integer, character varying, character varying, character varying,
+	character varying, character varying, boolean, character varying,
+	boolean, boolean, boolean, character varying, boolean,
+	OUT character varying, OUT INTEGER, OUT TEXT)
+  OWNER TO carpool_admins;
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_driver(	
+character varying, character varying, integer, character varying,
+	boolean, integer, character varying, character varying, character varying,
+	character varying, character varying, boolean, character varying,
+	boolean, boolean, boolean, character varying, boolean,
+	OUT character varying, OUT INTEGER, OUT TEXT) TO carpool_web_role;
+	
+GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_driver( 
+character varying, character varying, integer, character varying,
+	boolean, integer, character varying, character varying, character varying,
+	character varying, character varying, boolean, character varying,
+	boolean, boolean, boolean, character varying, boolean,
+	OUT character varying, OUT INTEGER, OUT TEXT) TO carpool_role;

--- a/db/fct_user_actions.sql
+++ b/db/fct_user_actions.sql
@@ -97,6 +97,8 @@ CREATE OR REPLACE FUNCTION carpoolvote.submit_new_rider(
 	a_RiderCollectionStreetNumber character varying,
     a_RiderCollectionAddress character varying,
     a_RiderDestinationAddress character varying,
+	a_RidingOnBehalfOfOrganization boolean,
+	a_RidingOBOOrganizationName character varying,
 	OUT out_uuid character varying,
 	OUT out_error_code INTEGER,
 	OUT out_error_text TEXT) AS
@@ -108,6 +110,7 @@ DECLARE
 	rider_time text;
 	start_ride_time timestamp without time zone;
 	end_ride_time timestamp without time zone;
+    uuid_organization character varying(50);
 
 	a_ip inet;
 BEGIN	
@@ -168,10 +171,27 @@ BEGIN
 			out_error_text := 'Invalid TotalPartySize: ' || a_TotalPartySize;
 			RETURN;
 		END IF;
-		
+
 		v_step := 'S7';
-		-- Preferred contact method validation
-		-- skipped
+		IF a_RidingOnBehalfOfOrganization IS NOT NULL and a_RidingOnBehalfOfOrganization IS TRUE
+		THEN 
+			IF a_RidingOBOOrganizationName IS NOT NULL and EXISTS (SELECT 1 FROM carpoolvote.organization o WHERE o."OrganizationName" = a_RidingOBOOrganizationName)
+			THEN
+				SELECT "UUID" FROM carpoolvote.organization o WHERE o."OrganizationName" = a_RidingOBOOrganizationName into uuid_organization;
+			ELSE
+				IF a_RidingOBOOrganizationName IS NULL 
+				THEN
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Invalid RidingOBOOrganizationName';
+					RETURN;
+				ELSE 
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Not Found RidingOBOOrganizationName:' || a_RidingOBOOrganizationName;
+					RETURN;
+				END IF;
+			END IF;
+		END IF;	
+
 		
 		v_step := 'S8';
 		out_uuid := carpoolvote.gen_random_uuid();
@@ -179,12 +199,12 @@ BEGIN
 		"UUID", "IPAddress", "RiderFirstName", "RiderLastName", "RiderEmail", "RiderPhone", "RiderCollectionZIP",
 		"RiderDropOffZIP", "AvailableRideTimesLocal", "TotalPartySize", "TwoWayTripNeeded", "RiderIsVulnerable",
 		"RiderWillNotTalkPolitics", "PleaseStayInTouch", "NeedWheelchair", "RiderPreferredContact",
-		"RiderAccommodationNotes", "RiderLegalConsent", "RiderWillBeSafe", "RiderCollectionStreetNumber", "RiderCollectionAddress", "RiderDestinationAddress")
+		"RiderAccommodationNotes", "RiderLegalConsent", "RiderWillBeSafe", "RiderCollectionStreetNumber", "RiderCollectionAddress", "RiderDestinationAddress", "uuid_organization")
 		VALUES (
 		out_uuid, a_IPAddress, a_RiderFirstName, a_RiderLastName, a_RiderEmail, a_RiderPhone, a_RiderCollectionZIP,
 		a_RiderDropOffZIP, a_AvailableRideTimesLocal, a_TotalPartySize, a_TwoWayTripNeeded, a_RiderIsVulnerable,
 		a_RiderWillNotTalkPolitics, a_PleaseStayInTouch, a_NeedWheelchair, a_RiderPreferredContact,
-		a_RiderAccommodationNotes, a_RiderLegalConsent, a_RiderWillBeSafe, a_RiderCollectionStreetNumber, a_RiderCollectionAddress, a_RiderDestinationAddress);
+		a_RiderAccommodationNotes, a_RiderLegalConsent, a_RiderWillBeSafe, a_RiderCollectionStreetNumber, a_RiderCollectionAddress, a_RiderDestinationAddress, uuid_organization);
 
 		v_step := 'S9';
 		SELECT * FROM carpoolvote.notify_new_rider(out_uuid) INTO out_error_code, out_error_text;
@@ -254,6 +274,8 @@ CREATE OR REPLACE FUNCTION carpoolvote.submit_new_rider(
     a_RiderWillBeSafe boolean,
     a_RiderCollectionAddress character varying,
     a_RiderDestinationAddress character varying,
+	a_RidingOnBehalfOfOrganization boolean,
+	a_RidingOBOOrganizationName character varying,
 	OUT out_uuid character varying,
 	OUT out_error_code INTEGER,
 	OUT out_error_text TEXT) AS
@@ -281,7 +303,9 @@ SELECT * FROM carpoolvote.submit_new_rider(
     a_RiderWillBeSafe,
 	NULL,  -- the street number
     a_RiderCollectionAddress,
-    a_RiderDestinationAddress) INTO 
+    a_RiderDestinationAddress,
+	a_RidingOnBehalfOfOrganization,
+	a_RidingOBOOrganizationName) INTO
 	out_uuid,
 	out_error_code,
 	out_error_text;
@@ -347,6 +371,8 @@ CREATE OR REPLACE FUNCTION carpoolvote.submit_new_driver(
 $BODY$
 DECLARE
 	v_step character varying(200);
+    uuid_organization character varying(50);
+	
 	a_ip inet;
 BEGIN	
 	
@@ -406,8 +432,24 @@ BEGIN
 		END IF;
 		
 		v_step := 'S7';
-		-- Preferred contact method validation
-		-- skipped
+		IF a_DrivingOnBehalfOfOrganization IS NOT NULL and a_DrivingOnBehalfOfOrganization IS TRUE
+		THEN 
+			IF a_DrivingOBOOrganizationName IS NOT NULL and EXISTS (SELECT 1 FROM carpoolvote.organization o WHERE o."OrganizationName" = a_DrivingOBOOrganizationName)
+			THEN
+				SELECT "UUID" FROM carpoolvote.organization o WHERE o."OrganizationName" = a_DrivingOBOOrganizationName into uuid_organization;
+			ELSE
+				IF a_DrivingOBOOrganizationName IS NULL 
+				THEN
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Invalid DrivingOBOOrganizationName';
+					RETURN;
+				ELSE 
+					out_error_code := carpoolvote.f_INPUT_VAL_ERROR();
+					out_error_text := 'Not Found DrivingOBOOrganizationName:' || a_DrivingOBOOrganizationName;
+					RETURN;
+				END IF;
+			END IF;
+		END IF;	
 		
 		
 		v_step := 'S8';

--- a/db/fct_user_actions.sql
+++ b/db/fct_user_actions.sql
@@ -459,14 +459,14 @@ BEGIN
 		"DriverCanLoadRiderWithWheelchair", "SeatCount", "DriverLicenseNumber", 
 		"DriverFirstName", "DriverLastName", "DriverEmail", "DriverPhone",
 		"DrivingOnBehalfOfOrganization", "DrivingOBOOrganizationName", "RidersCanSeeDriverDetails",
-		"DriverWillNotTalkPolitics", "PleaseStayInTouch", "DriverPreferredContact", "DriverWillTakeCare")
+		"DriverWillNotTalkPolitics", "PleaseStayInTouch", "DriverPreferredContact", "DriverWillTakeCare", "uuid_organization")
 		VALUES (
 		out_uuid, 
 		a_IPAddress, a_DriverCollectionZIP, a_DriverCollectionRadius, a_AvailableDriveTimesLocal, 
 		a_DriverCanLoadRiderWithWheelchair, a_SeatCount, a_DriverLicenseNumber, 
 		a_DriverFirstName, a_DriverLastName, a_DriverEmail, a_DriverPhone,
 		a_DrivingOnBehalfOfOrganization, a_DrivingOBOOrganizationName, a_RidersCanSeeDriverDetails,
-		a_DriverWillNotTalkPolitics, a_PleaseStayInTouch, a_DriverPreferredContact, a_DriverWillTakeCare
+		a_DriverWillNotTalkPolitics, a_PleaseStayInTouch, a_DriverPreferredContact, a_DriverWillTakeCare, uuid_organization
 		);
 		
 		v_step := 'S9';

--- a/db/test-simple.sql
+++ b/db/test-simple.sql
@@ -1,0 +1,1 @@
+select * from carpoolvote.tb_user;

--- a/docker/nodeApp/Dockerfile
+++ b/docker/nodeApp/Dockerfile
@@ -63,12 +63,14 @@ COPY ./expo-bash.sh /
 # these steps may be needed
 # https://github.com/moby/moby/issues/27182
 RUN chmod +x /expo-start.sh
+RUN chmod +x /expo-debug.sh
 RUN chmod +x /expo-bash.sh
 
 CMD ["/expo-start.sh"]
 
 # NOTES for dev support
 # CMD ["/expo-debug.sh"]
+# CMD ["/expo-bash.sh"]
 
 # RUN tsc  --target es2017 -w -p . &
 # node --inspect=0.0.0.0:5858 --inspect-brk index.js

--- a/nodeAppPostPg/DbQueriesPosts.js
+++ b/nodeAppPostPg/DbQueriesPosts.js
@@ -47,7 +47,7 @@ class DbQueriesPosts {
     dbGetSubmitRiderString() {
         return dbQueriesHelpers.dbSelectFromString(dbDefsSchema.SCHEMA_NAME, dbDefsSubmits.SUBMIT_RIDER_FN)
             + ' ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '
-            + '        $13, $14, $15, $16, $17, $18, $19, $20 )'; /* TODO add $21 for new a_RiderCollectionStreetNumber when form is ready */
+            + '        $13, $14, $15, $16, $17, $18, $19, $20, $21, $22 )'; /* TODO add $21 for new a_RiderCollectionStreetNumber when form is ready */
         /*
         a_IPAddress character varying,
           a_RiderFirstName character varying,
@@ -70,6 +70,8 @@ class DbQueriesPosts {
           a_RiderCollectionStreetNumber character varying,  --- 4/30: this is new field on the API, see backend issue #105
           a_RiderCollectionAddress character varying,
           a_RiderDestinationAddress character varying,
+          a_RidingOnBehalfOfOrganization boolean,
+          a_RidingOBOOrganizationName character varying,
         */
     }
     dbGetSubmitHelperString() {

--- a/nodeAppPostPg/DbQueriesPosts.ts
+++ b/nodeAppPostPg/DbQueriesPosts.ts
@@ -54,7 +54,7 @@ class DbQueriesPosts {
   dbGetSubmitRiderString(): string {
     return dbQueriesHelpers.dbSelectFromString(dbDefsSchema.SCHEMA_NAME, dbDefsSubmits.SUBMIT_RIDER_FN)
         + ' ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '
-        + '        $13, $14, $15, $16, $17, $18, $19, $20 )';  /* TODO add $21 for new a_RiderCollectionStreetNumber when form is ready */
+        + '        $13, $14, $15, $16, $17, $18, $19, $20, $21, $22 )';  /* TODO add $21 for new a_RiderCollectionStreetNumber when form is ready */
     /* 
     a_IPAddress character varying,
       a_RiderFirstName character varying,
@@ -77,8 +77,9 @@ class DbQueriesPosts {
       a_RiderCollectionStreetNumber character varying,  --- 4/30: this is new field on the API, see backend issue #105
       a_RiderCollectionAddress character varying,
       a_RiderDestinationAddress character varying,
-    */
-		
+      a_RidingOnBehalfOfOrganization boolean,
+      a_RidingOBOOrganizationName character varying,
+    */		
   }
 
   dbGetSubmitHelperString(): string {

--- a/nodeAppPostPg/PostFunctions.js
+++ b/nodeAppPostPg/PostFunctions.js
@@ -115,8 +115,8 @@ class PostFunctions {
             payload.RiderAccommodationNotes,
             (payload.RiderLegalConsent ? 'true' : 'false'),
             (payload.RiderWillBeSafe ? 'true' : 'false'),
-            payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
-            payload.RidingOBOOrganizationName,
+            payload.RiderCollectionAddress,
+            payload.RiderDestinationAddress,
             payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
             payload.RidingOBOOrganizationName
         ];

--- a/nodeAppPostPg/PostFunctions.js
+++ b/nodeAppPostPg/PostFunctions.js
@@ -95,7 +95,7 @@ class PostFunctions {
     }
     getRiderPayloadAsArray(self, req, payload) {
         var ip = self.getClientAddress(req);
-        return [
+        const payloadAsArray = [
             ip,
             payload.RiderFirstName,
             payload.RiderLastName,
@@ -115,9 +115,12 @@ class PostFunctions {
             payload.RiderAccommodationNotes,
             (payload.RiderLegalConsent ? 'true' : 'false'),
             (payload.RiderWillBeSafe ? 'true' : 'false'),
-            payload.RiderCollectionAddress,
-            payload.RiderDestinationAddress
+            payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
+            payload.RidingOBOOrganizationName,
+            payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
+            payload.RidingOBOOrganizationName
         ];
+        return payloadAsArray;
     }
     getUserPayloadAsArray(self, req, payload) {
         var ip = self.getClientAddress(req);

--- a/nodeAppPostPg/PostFunctions.ts
+++ b/nodeAppPostPg/PostFunctions.ts
@@ -163,7 +163,8 @@ class PostFunctions {
 
   getRiderPayloadAsArray (self: PostFunctions, req: any, payload: any): any[] {
     var ip = self.getClientAddress(req);
-    return [
+
+    const payloadAsArray = [
         ip,
         payload.RiderFirstName,
         payload.RiderLastName,
@@ -183,9 +184,13 @@ class PostFunctions {
         payload.RiderAccommodationNotes,
         (payload.RiderLegalConsent ? 'true' : 'false'),
         (payload.RiderWillBeSafe ? 'true' : 'false'),
-        payload.RiderCollectionAddress,
-        payload.RiderDestinationAddress
-    ];
+        payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
+        payload.RidingOBOOrganizationName,
+        payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
+        payload.RidingOBOOrganizationName
+      ];
+
+    return payloadAsArray;
   }
 
   getUserPayloadAsArray (self: PostFunctions, req: any, payload: any): any[] {

--- a/nodeAppPostPg/PostFunctions.ts
+++ b/nodeAppPostPg/PostFunctions.ts
@@ -184,8 +184,8 @@ class PostFunctions {
         payload.RiderAccommodationNotes,
         (payload.RiderLegalConsent ? 'true' : 'false'),
         (payload.RiderWillBeSafe ? 'true' : 'false'),
-        payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
-        payload.RidingOBOOrganizationName,
+        payload.RiderCollectionAddress,
+        payload.RiderDestinationAddress,
         payload.RidingOnBehalfOfOrganization ? 'true' : 'false',
         payload.RidingOBOOrganizationName
       ];

--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -41,11 +41,6 @@ module.exports = {
     dbGetUnmatchedRidersQueryString: dbGetUnmatchedRidersQueryString,
     dbGetDriversDetailssQueryString: dbGetDriversDetailssQueryString,
     dbGetDriverMatchesDetailsQueryString: dbGetDriverMatchesDetailsQueryString
-    // dbGetInsertClause:            dbGetInsertClause
-    // ,
-    // dbGetSubmitDriverString:      dbGetSubmitDriverString,
-    // dbGetSubmitRiderString:       dbGetSubmitRiderString,
-    // dbGetSubmitHelperString:      dbGetSubmitHelperString
 };
 // const dbDefs = require('./dbDefs.js');
 // exec fns

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -53,11 +53,6 @@ module.exports = {
   dbGetUnmatchedRidersQueryString: dbGetUnmatchedRidersQueryString,
   dbGetDriversDetailssQueryString: dbGetDriversDetailssQueryString,
   dbGetDriverMatchesDetailsQueryString: dbGetDriverMatchesDetailsQueryString
-  // dbGetInsertClause:            dbGetInsertClause
-  // ,
-  // dbGetSubmitDriverString:      dbGetSubmitDriverString,
-  // dbGetSubmitRiderString:       dbGetSubmitRiderString,
-  // dbGetSubmitHelperString:      dbGetSubmitHelperString
 };
 
 // const dbDefs = require('./dbDefs.js');


### PR DESCRIPTION
@dmilet this PR is the backend part of a change to store a choice of organization for new riders and drivers. The front-end will have a drop-down on the driver offer/drive request pages. 

No tables are changed. The submit_new_rider and submit_new_driver functions are changed and some organization table defaults are inserted at the end of the carpool schema file (these can be moved elsewhere if you want). That table is given the standard set of permissions so that it can be read by the rider/driver functions.

I've adjusted the submit_new_rider to have the same pattern as the driver function (although no new fields not stored) i.e. there are a_RidingOnBehalfOfOrganization and a_RidingOBOOrganizationName parameters. From these parameters an organization uuid is resolved and that is stored in the table. Where both fields are null or a_RidingOnBehalfOfOrganization is false, then null is stored as the org uuid. If a_RidingOnBehalfOfOrganization is true and a_RidingOBOOrganizationName exists in the org table, that is stored, otherwise an error is raised. There are two errors handlers as null causes the error to show no info (it seems that error handlers do this, too).

The submit_new_driver function is extended to have the same behaviour as the rider function.