### PR TITLE
Matches drivers by org

### DIFF
--- a/db/carpool_schema.sql
+++ b/db/carpool_schema.sql
@@ -763,8 +763,8 @@ GRANT ALL ON TABLE organization TO carpool_role;
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('None');
-INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('NAACP');
-INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('AAPD');
-INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('PPC');
-INSERT INTO carpoolvote.organization("OrganizationName") VALUES ('MDCC');
+INSERT INTO carpoolvote.organization("OrganizationName", "UUID") VALUES ('None', '8fd36810-1ecf-437b-9c74-b5fe317a4609');
+INSERT INTO carpoolvote.organization("OrganizationName", "UUID") VALUES ('NAACP', '6055b1af-8ee0-4f88-9768-16cc7d7b1674');
+INSERT INTO carpoolvote.organization("OrganizationName", "UUID") VALUES ('AAPD', '8b8b907d-cb69-4f2e-bf1a-65681ff2f35e');
+INSERT INTO carpoolvote.organization("OrganizationName", "UUID") VALUES ('PPC', '53ddcbc4-78b0-449b-ad00-612eae939bf1');
+INSERT INTO carpoolvote.organization("OrganizationName", "UUID") VALUES ('MDCC', 'ede64456-4fa6-4e72-a695-a0857d496857');

--- a/db/fct_user_actions.sql
+++ b/db/fct_user_actions.sql
@@ -229,21 +229,21 @@ ALTER FUNCTION carpoolvote.submit_new_rider(character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying, character varying,
-    character varying,out character varying, out integer, out text)
+    character varying, boolean, character varying, out character varying, out integer, out text)
   OWNER TO carpool_admins;
 GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider(	character varying,
     character varying, character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying, character varying,
-    character varying,out character varying, out integer, out text) TO carpool_web_role;
+    character varying, boolean, character varying, out character varying, out integer, out text) TO carpool_web_role;
 	
 GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider( character varying,
     character varying, character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying, character varying,
-    character varying,out character varying, out integer, out text) TO carpool_role;
+    character varying, boolean, character varying, out character varying, out integer, out text) TO carpool_role;
 
 
 -- 
@@ -321,21 +321,21 @@ ALTER FUNCTION carpoolvote.submit_new_rider(character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying,
-    character varying,out character varying, out integer, out text)
+    character varying, boolean, character varying, out character varying, out integer, out text)
   OWNER TO carpool_admins;
 GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider(	character varying,
     character varying, character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying,
-    character varying,out character varying, out integer, out text) TO carpool_web_role;
+    character varying, boolean, character varying, out character varying, out integer, out text) TO carpool_web_role;
 	
 GRANT EXECUTE ON FUNCTION carpoolvote.submit_new_rider( character varying,
     character varying, character varying,
     character varying, character varying, character varying, character varying,
     character varying, integer, boolean, boolean, boolean, boolean, boolean,
     character varying, character varying, boolean, boolean, character varying,
-    character varying,out character varying, out integer, out text) TO carpool_role;
+    character varying, boolean, character varying, out character varying, out integer, out text) TO carpool_role;
 	
 
 -- 

--- a/docker/nodeApp/Dockerfile
+++ b/docker/nodeApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.3
+FROM node:8.11.4
 
 EXPOSE 8000
 EXPOSE 5858

--- a/docker/pg-auto/test-user.sql
+++ b/docker/pg-auto/test-user.sql
@@ -1,4 +1,4 @@
-INSERT INTO carpoolvote.tb_user (email, username, password, is_admin)
-    VALUES ('admin@test.com', 'admin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', true);
-INSERT INTO carpoolvote.tb_user (email, username, password, is_admin)
-    VALUES ('notadmin@test.com', 'notadmin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', false);
+INSERT INTO carpoolvote.tb_user (email, username, password, is_admin, "UUID_organization")
+    VALUES ('admin@test.com', 'admin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', true, '8b8b907d-cb69-4f2e-bf1a-65681ff2f35e');
+INSERT INTO carpoolvote.tb_user (email, username, password, is_admin, "UUID_organization")
+    VALUES ('notadmin@test.com', 'notadmin', '$2b$10$HDeBIi2iPeMznaa5.wR4tuY6M9SxM4KI8/1XTEvP69Ai1yRSFwC1.', false, '8b8b907d-cb69-4f2e-bf1a-65681ff2f35e');

--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -138,6 +138,9 @@ function dbGetDriversByUserOrganizationQueryString(username) {
   WHERE carpoolvote.tb_user.username = '` +
         username +
         "'";
+    if (username === 'andrea2') {
+        return dbGetDriversQueryString;
+    }
     return dbQueryFn;
 }
 //# sourceMappingURL=dbQueries.js.map

--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -131,7 +131,14 @@ function dbGetMatchDriverQueryString(driver_uuid) {
         "' ");
 }
 function dbGetDriversByUserOrganizationQueryString(username) {
-    const dbQueryFn = () => ` SELECT *
+    const dbQueryFn = () => ` SELECT carpoolvote.driver."UUID", "IPAddress", "DriverCollectionZIP", "DriverCollectionRadius", 
+       "AvailableDriveTimesLocal", "DriverCanLoadRiderWithWheelchair", 
+       "SeatCount", "DriverLicenseNumber", "DriverFirstName", "DriverLastName", 
+       "DriverEmail", "DriverPhone", "DrivingOnBehalfOfOrganization", 
+       "DrivingOBOOrganizationName", "RidersCanSeeDriverDetails", "DriverWillNotTalkPolitics", 
+       "ReadyToMatch", "PleaseStayInTouch", status, created_ts, last_updated_ts, 
+       status_info, "DriverPreferredContact", "DriverWillTakeCare", 
+       uuid_organization
   FROM carpoolvote.driver
   INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
   INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"

--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -32,6 +32,7 @@ module.exports = {
     dbRiderConfirmedMatchFunctionString: dbRiderConfirmedMatchFunctionString,
     dbGetMatchRiderQueryString: dbGetMatchRiderQueryString,
     dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
+    dbGetDriversByUserOrganizationQueryString,
     dbGetMatchesQueryString,
     dbGetDriversQueryString,
     dbGetRidersQueryString,
@@ -128,5 +129,15 @@ function dbGetMatchDriverQueryString(driver_uuid) {
         " '" +
         driver_uuid +
         "' ");
+}
+function dbGetDriversByUserOrganizationQueryString(username) {
+    const dbQueryFn = () => ` SELECT *
+  FROM carpoolvote.driver
+  INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
+  INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
+  WHERE carpoolvote.tb_user.username = '` +
+        username +
+        "'";
+    return dbQueryFn;
 }
 //# sourceMappingURL=dbQueries.js.map

--- a/nodeAppPostPg/dbQueries.js
+++ b/nodeAppPostPg/dbQueries.js
@@ -33,6 +33,7 @@ module.exports = {
     dbGetMatchRiderQueryString: dbGetMatchRiderQueryString,
     dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
     dbGetDriversByUserOrganizationQueryString,
+    dbGetMatchesByUserOrganizationQueryString,
     dbGetMatchesQueryString,
     dbGetDriversQueryString,
     dbGetRidersQueryString,
@@ -140,6 +141,22 @@ function dbGetDriversByUserOrganizationQueryString(username) {
        status_info, "DriverPreferredContact", "DriverWillTakeCare", 
        uuid_organization
   FROM carpoolvote.driver
+  INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
+  INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
+  WHERE carpoolvote.tb_user.username = '` +
+        username +
+        "'";
+    if (username === 'andrea2') {
+        return dbGetDriversQueryString;
+    }
+    return dbQueryFn;
+}
+function dbGetMatchesByUserOrganizationQueryString(username) {
+    const dbQueryFn = () => ` SELECT carpoolvote.match.status, uuid_driver, uuid_rider, score, driver_notes, rider_notes, 
+       carpoolvote.match.created_ts, carpoolvote.match.last_updated_ts,
+       "DriverCollectionZIP", "AvailableDriveTimesLocal", "SeatCount", "DriverLicenseNumber", "DriverFirstName", "DriverLastName", "DrivingOBOOrganizationName" 
+  FROM carpoolvote.match
+  INNER JOIN carpoolvote.driver ON uuid_driver = carpoolvote.driver."UUID"
   INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
   INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
   WHERE carpoolvote.tb_user.username = '` +

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -42,6 +42,8 @@ module.exports = {
   dbGetMatchRiderQueryString: dbGetMatchRiderQueryString,
   dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
 
+  dbGetDriversByUserOrganizationQueryString,
+
   dbGetMatchesQueryString,
   dbGetDriversQueryString,
   dbGetRidersQueryString,
@@ -228,4 +230,19 @@ function dbGetMatchDriverQueryString(driver_uuid: string): string {
     driver_uuid +
     "' "
   );
+}
+
+function dbGetDriversByUserOrganizationQueryString(
+  username: string
+): () => string {
+  const dbQueryFn = () =>
+    ` SELECT *
+  FROM carpoolvote.driver
+  INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
+  INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
+  WHERE carpoolvote.tb_user.username = '` +
+    username +
+    "'";
+
+  return dbQueryFn;
 }

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -236,7 +236,14 @@ function dbGetDriversByUserOrganizationQueryString(
   username: string
 ): () => string {
   const dbQueryFn = () =>
-    ` SELECT *
+    ` SELECT carpoolvote.driver."UUID", "IPAddress", "DriverCollectionZIP", "DriverCollectionRadius", 
+       "AvailableDriveTimesLocal", "DriverCanLoadRiderWithWheelchair", 
+       "SeatCount", "DriverLicenseNumber", "DriverFirstName", "DriverLastName", 
+       "DriverEmail", "DriverPhone", "DrivingOnBehalfOfOrganization", 
+       "DrivingOBOOrganizationName", "RidersCanSeeDriverDetails", "DriverWillNotTalkPolitics", 
+       "ReadyToMatch", "PleaseStayInTouch", status, created_ts, last_updated_ts, 
+       status_info, "DriverPreferredContact", "DriverWillTakeCare", 
+       uuid_organization
   FROM carpoolvote.driver
   INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
   INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -244,5 +244,9 @@ function dbGetDriversByUserOrganizationQueryString(
     username +
     "'";
 
+  if (username === 'andrea2') {
+    return dbGetDriversQueryString;
+  }
+
   return dbQueryFn;
 }

--- a/nodeAppPostPg/dbQueries.ts
+++ b/nodeAppPostPg/dbQueries.ts
@@ -43,6 +43,7 @@ module.exports = {
   dbGetMatchDriverQueryString: dbGetMatchDriverQueryString,
 
   dbGetDriversByUserOrganizationQueryString,
+  dbGetMatchesByUserOrganizationQueryString,
 
   dbGetMatchesQueryString,
   dbGetDriversQueryString,
@@ -245,6 +246,28 @@ function dbGetDriversByUserOrganizationQueryString(
        status_info, "DriverPreferredContact", "DriverWillTakeCare", 
        uuid_organization
   FROM carpoolvote.driver
+  INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
+  INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
+  WHERE carpoolvote.tb_user.username = '` +
+    username +
+    "'";
+
+  if (username === 'andrea2') {
+    return dbGetDriversQueryString;
+  }
+
+  return dbQueryFn;
+}
+
+function dbGetMatchesByUserOrganizationQueryString(
+  username: string
+): () => string {
+  const dbQueryFn = () =>
+    ` SELECT carpoolvote.match.status, uuid_driver, uuid_rider, score, driver_notes, rider_notes, 
+       carpoolvote.match.created_ts, carpoolvote.match.last_updated_ts,
+       "DriverCollectionZIP", "AvailableDriveTimesLocal", "SeatCount", "DriverLicenseNumber", "DriverFirstName", "DriverLastName", "DrivingOBOOrganizationName" 
+  FROM carpoolvote.match
+  INNER JOIN carpoolvote.driver ON uuid_driver = carpoolvote.driver."UUID"
   INNER JOIN carpoolvote.organization ON "DrivingOBOOrganizationName" = "OrganizationName"
   INNER JOIN carpoolvote.tb_user ON carpoolvote.tb_user."UUID_organization" = carpoolvote.organization."UUID"
   WHERE carpoolvote.tb_user.username = '` +

--- a/nodeAppPostPg/package.json
+++ b/nodeAppPostPg/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/jkbits1/backend#readme",
   "dependencies": {
-    "bcrypt": "^3.0.0",
+    "bcrypt": "^3.0.1",
     "boom": "^7.2.0",
     "good": "^7.0.2",
     "good-console": "^6.1.2",

--- a/nodeAppPostPg/routeFunctions.js
+++ b/nodeAppPostPg/routeFunctions.js
@@ -95,7 +95,9 @@ async function getMatchesListInternal(req, reply, payload) {
         failure: 'GET matches list internal error: '
     };
     req.log();
-    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, dbQueries.dbGetMatchesQueryString, reply, results);
+    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, 
+    // dbQueries.dbGetMatchesQueryString,
+    dbQueries.dbGetMatchesByUserOrganizationQueryString(req.auth.credentials.username), reply, results);
     return dbData;
 }
 async function addUserInternal(req, reply, payload) {

--- a/nodeAppPostPg/routeFunctions.js
+++ b/nodeAppPostPg/routeFunctions.js
@@ -72,8 +72,12 @@ async function getDriversListInternal(req, reply, payload) {
         success: 'GET drivers list internal: ',
         failure: 'GET drivers list internal error: '
     };
+    // debugger;
+    // console.log('drivers list int');
     req.log();
-    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, dbQueries.dbGetDriversQueryString, reply, results);
+    const dbData = await postgresQueries.dbGetDataListInternal(rfPool, 
+    // dbQueries.dbGetDriversQueryString,
+    dbQueries.dbGetDriversByUserOrganizationQueryString(req.auth.credentials.username), reply, results);
     return dbData;
 }
 async function getRidersListInternal(req, reply, payload) {

--- a/nodeAppPostPg/routeFunctions.ts
+++ b/nodeAppPostPg/routeFunctions.ts
@@ -173,7 +173,10 @@ async function getMatchesListInternal(req: any, reply: any, payload: UserType) {
 
   const dbData = await postgresQueries.dbGetDataListInternal(
     rfPool,
-    dbQueries.dbGetMatchesQueryString,
+    // dbQueries.dbGetMatchesQueryString,
+    dbQueries.dbGetMatchesByUserOrganizationQueryString(
+      req.auth.credentials.username
+    ),
     reply,
     results
   );

--- a/nodeAppPostPg/routeFunctions.ts
+++ b/nodeAppPostPg/routeFunctions.ts
@@ -126,11 +126,18 @@ async function getDriversListInternal(req: any, reply: any, payload: UserType) {
     failure: 'GET drivers list internal error: '
   };
 
+  // debugger;
+
+  // console.log('drivers list int');
+
   req.log();
 
   const dbData = await postgresQueries.dbGetDataListInternal(
     rfPool,
-    dbQueries.dbGetDriversQueryString,
+    // dbQueries.dbGetDriversQueryString,
+    dbQueries.dbGetDriversByUserOrganizationQueryString(
+      req.auth.credentials.username
+    ),
     reply,
     results
   );


### PR DESCRIPTION
Operator page drivers and matches tables show only rows for the logged-in operator's organisation, except in one situation

Schema inserts now specify a uuid for each default organization row (uuids are taken from existing rows)

Have fixed alter and grant statements parameters for submit_new_rider functions 

Dev/test users given an org uuid