### PR TITLE
resolve docker env issues for front-end

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -43,25 +43,25 @@ Carpool-vote is spread across two repos, one for front-end the other for backend
 
 **Front-end code folder**
 
-The default value for the front-end folder is `voteUSfrontend`. This can be changed by either editing the `COMPOSE_DEV_FE_DIR` variable in the `.env` file (in the docker folder) or by setting this as an environment variable.
-
-`export COMPOSE_DEV_FE_DIR=...` See the [docker documentation](https://docs.docker.com/compose/compose-file/compose-file-v2/#variable-substitution) for details.
-
 It is assumed that you already have a a local clone of the frontend repo, but if not, create one:
 
 `git clone https://github.com/your-fork-name-here/voteamerica.github.io voteUSfrontend`
 
+As in the example command above, the expected name for the front-end folder is `voteUSfrontend`. Alternate names can be supported by either editing the `COMPOSE_DEV_FE_DIR` variable in the `.env` file (in the docker folder) or by setting this as an environment variable.
+
+`export COMPOSE_DEV_FE_DIR=...` See the [docker documentation](https://docs.docker.com/compose/compose-file/compose-file-v2/#variable-substitution) for details.
+
 **Back-end code folder**
 
-If it does not already exist, clone the backend git repo. It can be named however you wish. Here it is called `voteUSbackend`.
+If it does not already exist, clone the backend git repo. It can be named however you wish. In the example command below, and in these instructions, it is called `voteUSbackend`.
 
 `git clone https://github.com/your-fork-name-here/backend voteUSbackend`
 
 #### Create specific machines (if required)
 
-This can be necessary for testing against a version of code that is under development or in a non-default branch and/or repo.
+This can be necessary for testing against a version of code that is under development or in a non-default branch and/or repo. If you are just starting with setting up the environment, then continue to the next section and refer back to these details later if necessary.
 
-Example params to these scripts
+Example params to these scripts:
 
 `cp-nodejs` the service name in the relevant docker-compose .yml file
 
@@ -74,6 +74,8 @@ Example params to these scripts
 More details below.
 
 ### 1) Front-end Development
+
+This set-up needs a little less work than the Full-stack version. However, that version is used more (so is more tested and documented), so if just starting, you may be better off with the the Full-stack version, even if there is a little more set-up involved.
 
 #### Go to the docker folder ...
 
@@ -111,7 +113,7 @@ docker-compose -f ./compose/full-stack-local/docker-compose-local-frontend.yml d
 
 This works directly from the files in the folders for your front and back-end repos.
 
-If you don't have a local clone of the front-end repo, create one as described above.
+If you have not gone through the initial steps and don't have a local clone of the front-end repo, create one as described above.
 
 #### Create specific machines (if required)
 

--- a/docker/compose/full-stack-local/docker-compose-local-fullstack.yml
+++ b/docker/compose/full-stack-local/docker-compose-local-fullstack.yml
@@ -39,6 +39,10 @@ services:
     volumes:
       - ../../../../${COMPOSE_DEV_FE_DIR:-voteUSfrontend}:/usr/src/app/frontend
 
+      # This volume is needed for node modules, so the packages installed  
+      # by the Dockerfile are visible when the container is started.
+      - front_end_node_modules:/usr/src/app/frontend/node_modules/
+
     networks:
       vpcbr:
         ipv4_address: 10.4.0.4
@@ -73,6 +77,9 @@ services:
       - cp-pg-server
     volumes:
       - ../../..:/usr/src/app/backend
+
+      # This volume is needed for node modules, so the packages installed  
+      # by the Dockerfile are visible when the container is started.
       - node_app_node_modules:/usr/src/app/backend/nodeAppPostPg/node_modules/
 
     networks:
@@ -133,3 +140,4 @@ networks:
 
 volumes:
   node_app_node_modules:
+  front_end_node_modules:

--- a/docker/jekyllDev/Dockerfile
+++ b/docker/jekyllDev/Dockerfile
@@ -47,10 +47,17 @@ RUN git fetch origin
 RUN git merge origin/$BRANCH_NAME
 
 # RUN npm install --only=dev
-# RUN npm install 
-# RUN yarn install --production=false
 
-# TEST  
+# This works, so will stick with npm for now. However, the yarn install sends a lot 
+# less info to the console when it builds the bs-platform. It would be handy to get 
+# npm to do the same.
+RUN npm install 
+# RUN yarn install --production=false
+# RUN yarn
+
+# WIP - maybe try these steps re global bsb on linux.
+# https://github.com/BuckleScript/bucklescript/issues/2051#issuecomment-331387417
+# For now, copy across the two reasonreact*.js files in the start script below.
 # RUN bsb -make-world
 
 # run webpack as background task

--- a/docker/jekyllDev/expo-start.sh
+++ b/docker/jekyllDev/expo-start.sh
@@ -2,6 +2,16 @@
 
 echo 'expo-start'
 
+# creates node_modules correctly - can it affect volume files?
+# review
+yarn
+
+cp /usr/src/app/frontend/scripts/ReasonReact.js  /usr/src/app/frontend/node_modules/reason-react/src/ReasonReact.js  
+
+cp /usr/src/app/frontend/scripts/ReasonReactOptimizedCreateClass.js  /usr/src/app/frontend/node_modules/reason-react/src/ReasonReactOptimizedCreateClass.js  
+
+echo "copied Reason files"
+
 jekyll serve -H 0.0.0.0 --force_polling --source /usr/src/app/frontend --destination /usr/src/app/frontend/_site --config /_config-local-host.yml &
 # run webpack as background task
 webpack --watch --progress --info-verbosity verbose --config development-webpack.config.js &

--- a/docker/jekyllDev/expo-start.sh
+++ b/docker/jekyllDev/expo-start.sh
@@ -2,13 +2,16 @@
 
 echo 'expo-start'
 
-# creates node_modules correctly - can it affect volume files?
-# review
-yarn
-
+# These are standard files required for the ReasonML files.
+# At some point, the bs-platform bsb may be started to generate them,
+# but this interim method provides all devs with an env that builds the React app.
 cp /usr/src/app/frontend/scripts/ReasonReact.js  /usr/src/app/frontend/node_modules/reason-react/src/ReasonReact.js  
 
 cp /usr/src/app/frontend/scripts/ReasonReactOptimizedCreateClass.js  /usr/src/app/frontend/node_modules/reason-react/src/ReasonReactOptimizedCreateClass.js  
+
+# These files don't display when the container is built, but do when the
+# docker compose env is started.
+ls /usr/src/app/frontend/node_modules/reason-react/src
 
 echo "copied Reason files"
 


### PR DESCRIPTION
Add a named volume for front-end in full-stack env (resolves issue with `webpack-merge` not found)

Copy across standard reason-react*.js files (so env builds ReasonML components)

In readme, give specific guidance to new users
